### PR TITLE
[PKG-1993] rebuild for icu-73.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,8 @@
+channels:
+  icu73: icu73
+
+aggregate_branch: icu-73.1
+
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.2.32" %}
+{% set version = "1.2.37" %}
 
 package:
   name: libxmlsec1
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://www.aleksey.com/xmlsec/download/xmlsec1-{{ version }}.tar.gz
-  sha256: e383702853236004e5b08e424b8afe9b53fe9f31aaa7a5382f39d9533eb7c043
+  sha256: 5f8dfbcb6d1e56bddd0b5ec2e00a3d0ca5342a9f57c24dffde5c796b2be2871c
 
 build:
-  number: 1
+  number: 0
   # libgpg-error and libgcrypt aren't available on s390x
   skip: true  # [win or (linux and s390x)]
   run_exports:
@@ -22,7 +22,7 @@ requirements:
     - make
     - libtool
   host:
-    - icu
+    - icu {{ icu }}
     - libgcrypt 1.9.3
     - libgpg-error 1.42
     - libiconv 1.16  # [not linux]
@@ -58,3 +58,8 @@ about:
     The library supports major XML security standards.
   dev_url: https://github.com/lsh123/xmlsec
   doc_url: https://www.aleksey.com/xmlsec/documentation.html
+
+extra:
+  skip-lints:  # due to the libtool issue explained above
+    - host_section_needs_exact_pinnings
+    - build_tools_must_be_in_build


### PR DESCRIPTION
Had to upgrade to `1.2.37` because sources are not available anymore for our built version. There's a `1.3.1` version also available but it introduces ABI changes, that would require rebuilds for reverse dependencies.

Depends on:
- https://github.com/AnacondaRecipes/icu-feedstock/pull/3
- https://github.com/AnacondaRecipes/libxml2-feedstock/pull/10
- https://github.com/AnacondaRecipes/libxslt-feedstock/pull/3