### PR TITLE
update to 11.2.37 and build against new openssl

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,8 +14,7 @@ export LIBXML_LIBS="-lxml2"
     --disable-docs \
     --with-openssl="${PREFIX}" \
     --with-libxml="${PREFIX}" \
-    --with-xslt="${PREFIX}" \
-    --with-gcrypt="${PREFIX}"
+    --with-xslt="${PREFIX}"
 make -j${CPU_COUNT} ${VERBOSE_AT}
 make check
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,19 +26,16 @@ requirements:
     - libgcrypt 1.9.3
     - libgpg-error 1.42
     - libiconv 1.16  # [not linux]
-    - libtool
     - libxml2 {{ libxml2 }}
     - libxslt 1.1.37
     - openssl {{ openssl }}
     - xz
     - zlib 1.2.13
   run:
-    # libltdl is linked, which the libtool package provides.
-    # This is needed to enable dynamic loading support for xmlsec-crypto
-    # libraries (--enable-crypto-dl option).
-    - {{ pin_compatible('libtool') }}
-    - {{ pin_compatible('xz') }}
-    - {{ pin_compatible('zlib') }}
+    - libxslt
+    - libxml2
+    - libgcrypt
+    - openssl
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,6 @@ requirements:
     - libtool
   host:
     - icu
-    - libgcrypt 1.9.3
     - libgpg-error 1.42
     - libiconv 1.16  # [not linux]
     - libtool

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,15 +22,11 @@ requirements:
     - make
     - libtool
   host:
-    - icu
-    - libgpg-error 1.42
-    - libiconv 1.16  # [not linux]
+    - libgpg-error 1.42 # [linux]
     - libtool
     - libxml2 {{ libxml2 }}
     - libxslt 1.1.37
     - openssl {{ openssl }}
-    - xz
-    - zlib 1.2.13
   run:
     - libtool
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - libgcrypt 1.9.3
     - libgpg-error 1.42
     - libiconv 1.16  # [not linux]
+    - libtool
     - libxml2 {{ libxml2 }}
     - libxslt 1.1.37
     - openssl {{ openssl }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,9 +32,8 @@ requirements:
     - xz
     - zlib 1.2.13
   run:
-    - libxslt
-    - libxml2
-    - libgcrypt
+    - {{ pin_compatible('xz') }}
+    - {{ pin_compatible('zlib') }}
     - openssl
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,13 +32,6 @@ requirements:
     - openssl {{ openssl }}
     - xz
     - zlib 1.2.13
-  run:
-    # libltdl is linked, which the libtool package provides.
-    # This is needed to enable dynamic loading support for xmlsec-crypto
-    # libraries (--enable-crypto-dl option).
-    - {{ pin_compatible('libtool') }}
-    - {{ pin_compatible('xz') }}
-    - {{ pin_compatible('zlib') }}
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - make
     - libtool
   host:
+    - libgcrypt 1.9.3
     - libgpg-error 1.42 # [linux]
     - libtool
     - libxml2 {{ libxml2 }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,8 +40,9 @@ test:
 
 about:
   home: https://www.aleksey.com/xmlsec/
-  license: MIT and MPL-1.1
-  license_family: Other
+  # conda-forge includes MPL-1.1 but is only applicable to xmlsec-nss
+  license: MIT
+  license_family: MIT
   license_file: Copyright
   summary: XML Security Library
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.2.32" %}
+{% set version = "1.2.37" %}
 
 package:
   name: libxmlsec1
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://www.aleksey.com/xmlsec/download/xmlsec1-{{ version }}.tar.gz
-  sha256: e383702853236004e5b08e424b8afe9b53fe9f31aaa7a5382f39d9533eb7c043
+  sha256: 5f8dfbcb6d1e56bddd0b5ec2e00a3d0ca5342a9f57c24dffde5c796b2be2871c
 
 build:
   number: 1
@@ -27,9 +27,9 @@ requirements:
     - libgpg-error 1.42
     - libiconv 1.16  # [not linux]
     - libtool
-    - libxml2 2.10
+    - libxml2 {{ libxml2 }}
     - libxslt 1.1.37
-    - openssl 1.1.1
+    - openssl 3.*
     - xz
     - zlib 1.2.13
   run:
@@ -50,7 +50,7 @@ test:
 about:
   home: https://www.aleksey.com/xmlsec/
   license: MIT and MPL-1.1
-  license_family: MIT
+  license_family: Other
   license_file: Copyright
   summary: XML Security Library
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,9 +32,12 @@ requirements:
     - xz
     - zlib 1.2.13
   run:
+    # libltdl is linked, which the libtool package provides.
+    # This is needed to enable dynamic loading support for xmlsec-crypto
+    # libraries (--enable-crypto-dl option).
+    - {{ pin_compatible('libtool') }}
     - {{ pin_compatible('xz') }}
     - {{ pin_compatible('zlib') }}
-    - openssl
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,3 +48,9 @@ about:
     The library supports major XML security standards.
   dev_url: https://github.com/lsh123/xmlsec
   doc_url: https://www.aleksey.com/xmlsec/documentation.html
+
+extra:
+  skip-lints:
+    - host_section_needs_exact_pinnings
+    - build_tools_must_be_in_build
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - libtool
     - libxml2 {{ libxml2 }}
     - libxslt 1.1.37
-    - openssl 3.*
+    - openssl {{ openssl }}
     - xz
     - zlib 1.2.13
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,8 @@ requirements:
     - openssl {{ openssl }}
     - xz
     - zlib 1.2.13
+  run:
+    - libtool
 
 test:
   requires:


### PR DESCRIPTION
- [x] updated to 11.2.37
- [x] checked upstream project for requirements in `autoconf` files 
- [x] checked license file