### PR TITLE
[PKG-1993] upgrade to 1.2.38

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.2.37" %}
+{% set version = "1.2.38" %}
 
 package:
   name: libxmlsec1
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://www.aleksey.com/xmlsec/download/xmlsec1-{{ version }}.tar.gz
-  sha256: 5f8dfbcb6d1e56bddd0b5ec2e00a3d0ca5342a9f57c24dffde5c796b2be2871c
+  sha256: 9de8cf8d7d2e288a9cef205cc6cb93c926a67dadfaf44aaff76ed63c28ce9902
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://www.aleksey.com/xmlsec/download/xmlsec1-{{ version }}.tar.gz
+  url: https://github.com/lsh123/xmlsec/releases/download/xmlsec-{{ version | replace(".", "_") }}/xmlsec1-{{ version }}.tar.gz
   sha256: 9de8cf8d7d2e288a9cef205cc6cb93c926a67dadfaf44aaff76ed63c28ce9902
 
 build:


### PR DESCRIPTION
Whenever upstream releases a new version addressing some security flaw, they remove the old one, breaking this build.

Side note: libxmlsec1 builds are mostly not reproducible because of that, do we want to mirror this sources? The fact that upstream removes the old tarballs due to security flaws may look like a good idea, but it forbids patching and enforces an upgrade that may not be wanted at the time (e.g. if the new version is not strictly a bugfix and includes some new features).