### PR TITLE
libxmlsec1 1.3.8 

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -13,7 +13,8 @@ export LIBXML_LIBS="-lxml2"
     --disable-docs \
     --with-openssl="${PREFIX}" \
     --with-libxml="${PREFIX}" \
-    --with-gcrypt="${PREFIX}"
+    --with-gcrypt="${PREFIX}" \
+    --with-xslt="${PREFIX}"
 make -j${CPU_COUNT} ${VERBOSE_AT}
 make check
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,13 +23,13 @@ requirements:
     - make
     - libtool
   host:
-    # GCRYPT_MIN_VERSION=1.4.0
+    # https://github.com/lsh123/xmlsec/blob/xmlsec_1_3_8/configure.ac#L1567 -> GCRYPT_MIN_VERSION=1.4.0
     - libgcrypt 1.11.2
     - libgpg-error 1.51
     - libtool 2.4.7
-    # LIBXML2_MIN_VERSION=2.8.0
+    # https://github.com/lsh123/xmlsec/blob/xmlsec_1_3_8/configure.ac#L331 -> LIBXML_MIN_VERSION=2.8.0
     - libxml2 {{ libxml2 }}
-    # LIBXSLT_MIN_VERSION=1.0.20
+    # https://github.com/lsh123/xmlsec/blob/xmlsec_1_3_8/configure.ac#L509 -> LIBXSLT_MIN_VERSION=1.0.20
     - libxslt {{ libxslt }}
     - openssl {{ openssl }}
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,8 @@ requirements:
     # LIBXSLT_MIN_VERSION=1.0.20
     - libxslt {{ libxslt }}
     - openssl {{ openssl }}
+  run:
+    - {{ pin_compatible('libtool') }}
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - make
+    - libtool
   host:
     # GCRYPT_MIN_VERSION=1.4.0
     - libgcrypt 1.11.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ requirements:
     - libxslt {{ libxslt }}
     - openssl {{ openssl }}
   run:
+    # Needed to resolve libltdl.so.7 in the dynamic section for libxmlsec1.so
     - {{ pin_compatible('libtool') }}
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
-{% set version = "1.3.5" %}
+{% set version = "1.3.8" %}
+{% set name = "libxmlsec1" %}
 
 package:
   name: libxmlsec1
@@ -6,32 +7,30 @@ package:
 
 source:
   url: https://github.com/lsh123/xmlsec/releases/download/{{ version }}/xmlsec1-{{ version }}.tar.gz
-  sha256: 2ffd4ad1f860ec93e47a680310ab2bc94968bd07566e71976bd96133d9504917
+  sha256: d0180916ae71be28415a6fa919a0684433ec9ec3ba1cc0866910b02e5e13f5bd
+
 build:
   number: 0
-  # libgpg-error and libgcrypt aren't available on s390x
-  skip: true  # [win or (linux and s390x)]
   run_exports:
     # compatibility is not tracked at abi-laboratory, assume same as libxml2
     - {{ pin_subpackage('libxmlsec1', max_pin='x.x') }}
+  skip: true  # [win]
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - make
-    - libtool
   host:
-    - libgcrypt 1.9.3
-    - libgpg-error 1.42  # [linux]
-    - libtool 2.4.6
+    # GCRYPT_MIN_VERSION=1.4.0
+    - libgcrypt 1.11.2
+    - libgpg-error 1.51
+    - libtool 2.4.7
+    # LIBXML2_MIN_VERSION=2.8.0
     - libxml2 {{ libxml2 }}
+    # LIBXSLT_MIN_VERSION=1.0.20
     - libxslt {{ libxslt }}
     - openssl {{ openssl }}
-  run:
-    # libltdl is linked, which the libtool package provides.
-    # This is needed to enable dynamic loading support for xmlsec-crypto
-    # libraries (--enable-crypto-dl option).
-    - {{ pin_compatible('libtool') }}
 
 test:
   requires:
@@ -41,7 +40,7 @@ test:
     - xmlsec1 --version | rg {{ version }}
 
 about:
-  home: https://www.aleksey.com/xmlsec/
+  home: https://www.aleksey.com/xmlsec
   license: MIT
   license_family: MIT
   license_file: Copyright


### PR DESCRIPTION
libxmlsec1 1.3.8 

**Destination channel:** Defaults

### Links

- [PKG-10455]
- dev_url:        https://github.com/lsh123/xmlsec/tree/xmlsec_1_3_8
- build_script: https://github.com/lsh123/xmlsec/blob/xmlsec_1_3_8/configure.ac
- conda_forge:    https://github.com/conda-forge/libxmlsec1-feedstock

### Explanation of changes:

- new version number


[PKG-10455]: https://anaconda.atlassian.net/browse/PKG-10455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ